### PR TITLE
Add automated Let's Encrypt certificate renewal for GitLab

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -1,0 +1,31 @@
+# RITlug GitLab
+
+## About
+
+The [RITlug GitLab](https://git.ritlug.com) is a hosted, Community Edition (CE) GitLab instance.
+This GitLab instance runs on [Titan](http://runbook.ritlug.com/infrastructure/hosted-server/).
+
+
+## Contents
+
+RITlug's GitLab requires several custom files for operation. 
+
+
+### gitlab-renew-cert.timer
+
+This `systemd` timer is used to renew the https://git.ritlug.com Let's Encrypt certificate.
+Currently, this cert is set to renew every Wednesday at 3AM EDT.
+
+
+### gitlab-renew-cert.service
+
+This `systemd` service file is used in conjunction with `gitlab-renew-cert.timer`.
+Once the date and time of the systemd timer is reached, this service file is executed.
+
+
+### gitlab-renew-cert
+
+This script is the main culprit for renewing the GitLab web certificate.
+It is located under `/usr/local/bin/` and is executed by the `systemd` service file.
+Its contents temporarily shuts down the RITlug GitLab, renews the Let's Encrypt cert, and starts up GitLab.
+GitLab cannot be running at the time of the cert renewal.

--- a/gitlab/gitlab-renew-cert
+++ b/gitlab/gitlab-renew-cert
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#######################################################
+# File: gitlab-renew-cert                             #
+# Description: Renew RITlug GitLab Let's Encrypt cert #
+# Author: Tim Zabel <tjzabel@protonmail.com>	      #
+#######################################################
+
+function renew_cert {
+
+    gitlab-ctl stop
+    certbot renew
+    gitlab-ctl start
+
+    exit $?
+}
+
+renew_cert

--- a/gitlab/gitlab-renew-cert
+++ b/gitlab/gitlab-renew-cert
@@ -3,7 +3,7 @@
 #######################################################
 # File: gitlab-renew-cert                             #
 # Description: Renew RITlug GitLab Let's Encrypt cert #
-# Author: Tim Zabel <tjzabel@protonmail.com>	      #
+# Author: Tim Zabel <tjzabel@protonmail.com>          #
 #######################################################
 
 function renew_cert {

--- a/gitlab/gitlab-renew-cert.service
+++ b/gitlab/gitlab-renew-cert.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Renew RITlug GitLab web cert
+Requires=network.target
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/gitlab-renew-cert

--- a/gitlab/gitlab-renew-cert.timer
+++ b/gitlab/gitlab-renew-cert.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Renew RITlug GitLab web cert
+
+[Timer]
+# Renew cert weekly on Wednesdays at 3AM EDT
+OnCalendar=Wed *-*-* 03:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What this is
This PR starts the initial process of documenting all custom files that live on any currently-active VMs within RITlug's infrastructure. Specifically, this PR automates the Let's Encrypt certificate renewal process for the [RITlug GitLab](https://git.ritlug.com). Once this is merged, work will begin on doing this for each necessary service.