### PR TITLE
ExecStart requires /bin/bash for script execution.

### DIFF
--- a/gitlab/gitlab-renew-cert.service
+++ b/gitlab/gitlab-renew-cert.service
@@ -5,4 +5,4 @@ After=multi-user.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/gitlab-renew-cert
+ExecStart=/bin/bash /usr/local/bin/gitlab-renew-cert


### PR DESCRIPTION
This has been tested, and is currently running in production.